### PR TITLE
typo

### DIFF
--- a/src/CryptoNoteCore/RocksDBWrapper.cpp
+++ b/src/CryptoNoteCore/RocksDBWrapper.cpp
@@ -80,7 +80,7 @@ void RocksDBWrapper::shutdown() {
   state.store(NOT_INITIALIZED);
 }
 
-void RocksDBWrapper::destoy(const DataBaseConfig& config) {
+void RocksDBWrapper::destroy(const DataBaseConfig& config) {
   if (state.load() != NOT_INITIALIZED) {
     throw std::system_error(make_error_code(CryptoNote::error::DataBaseErrorCodes::ALREADY_INITIALIZED));
   }


### PR DESCRIPTION
void RocksDBWrapper::destoy(const DataBaseConfig& config) {
void RocksDBWrapper::destroy(const DataBaseConfig& config) {